### PR TITLE
Proposta: remover nomes de gente escrota

### DIFF
--- a/scripts/persons.js
+++ b/scripts/persons.js
@@ -1,10 +1,4 @@
 const Persons = {
-  ney: {
-    name: 'Neymar Jr',
-    username: 'neymarjr',
-    msg: 'Saudade do que a gente não viveu ainda!!',
-    image: 'https://i.imgur.com/k2Uah9s.jpg'
-  },
   negodi: {
     name: 'Nego Di',
     username: 'negodioficial',
@@ -40,18 +34,6 @@ const Persons = {
     username: '10Ronaldinho',
     msg: 'Esse PR é aleatório d+ até pros meus padrões',
     image: 'https://i.imgur.com/D2YmPkl.jpg'
-  },
-  trump: {
-    name: 'Donald J. Trump',
-    username: 'realDonaldTrump',
-    msg: "It's easier win the third world war than review this PR",
-    image: 'https://i.imgur.com/UCtZwck.jpg'
-  },
-  jair: {
-    name: 'Jair M. Bolsonaro',
-    username: 'jairbolsonaro',
-    msg: 'PR legal. Grande abraço 👍🏻',
-    image: 'https://i.imgur.com/UrxtArM.jpg'
   },
   joelsantana: {
     name: 'Joel Santana',
@@ -197,30 +179,11 @@ const Persons = {
     msg: 'E o pau TORANDO na timeline',
     image: 'https://i.imgur.com/W2cVcsK.jpg'
   },
-  carluxo: {
-    name: 'Carluxo',
-    username: 'CarlosBolsonaro',
-    msg:
-      'Com a vitória no primeiro turno, vamos acabar com o PR e com as ISSUES. É a última vez que eles terão CODE REVIEW.',
-    image: 'https://i.imgur.com/vOPLfoV.jpg'
-  },
   davyjones: {
     name: 'Davy Jones',
     username: 'DavyJonesRJ',
     msg: 'Ae, seu PR é maneirão hein',
     image: 'https://i.imgur.com/2gyjYjP.jpg'
-  },
-  pecesiqueira: {
-    name: 'PC Siqueira',
-    username: 'PCSiqueira',
-    msg: 'Mas poxa vida, que PR da hora!',
-    image: 'https://i.imgur.com/Ywih160.jpg'
-  },
-  datena: {
-    name: 'Datena',
-    username: 'DatenaOficial',
-    msg: 'Eu quero ibágens desse conflito!',
-    image: 'https://i.imgur.com/w1y5zWB.jpg'
   },
   filipedeschamps: {
     name: 'Filipe Deschamps',
@@ -239,12 +202,6 @@ const Persons = {
     username: 'GalvaoBueno',
     msg: 'Conflitoooooouuuuuuuu!!!!!!!.',
     image: 'https://i.imgur.com/8DiTArM.jpg?1'
-  },
-  dadodollabela: {
-    name: 'Dado Dollabela',
-    username: 'dadodolabeIla',
-    msg: 'Tu traiu o movimento Clean Code, véio!',
-    image: 'https://i.imgur.com/YsLeAi9.jpg'
   },
   bigsmoke: {
     name: 'Big Smoke',


### PR DESCRIPTION
Independente da orientação política/ética de quem criou/contribui para
este projeto, toda vez que um dos nomes dessas pessoas é repetido, ele
permanece no tempo. E se tem uma coisa que esse bando merece é o
esquecimento absoluto. Agressores, fascistas, pedófilos e
sensacionalistas de violência não deveriam ser exemplos para ninguém nem
merecem ser usados para algo saudável e divertido como é o propósito
deste projeto :smile: