### PR TITLE
Fix: Manter tweet digitado ao trocar de template

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -172,7 +172,7 @@ export default defineComponent({
         tweet.msg = match?.msg ?? msg
       }
 
-      setSearch(tweet.msg)
+      setSearch(msg)
       setCurrentTweet(tweet)
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -121,7 +121,10 @@ export default defineComponent({
       currentIndex = currentIndex >= persons.length - 1 ? 0 : currentIndex += 1
       const tweet = persons[currentIndex]
       animateNext(store.tweetRef, {
-        onExitFinish: () => setCurrentTweet(tweet)
+        onExitFinish: () => setCurrentTweet({
+          ...tweet,
+          msg: store.search.length ? store.search : tweet.msg
+        })
       })
     }
 
@@ -129,7 +132,10 @@ export default defineComponent({
       currentIndex = currentIndex <= 0 ? persons.length - 1 : currentIndex -= 1
       const tweet = persons[currentIndex]
       animatePrevious(store.tweetRef, {
-        onExitFinish: () => setCurrentTweet(tweet)
+        onExitFinish: () => setCurrentTweet({
+          ...tweet,
+          msg: store.search.length ? store.search : tweet.msg
+        })
       })
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -177,7 +177,10 @@ export default defineComponent({
     }
 
     function handleTemplateChange (template: Person): void {
-      setCurrentTweet(template)
+      setCurrentTweet({
+        ...template,
+        msg: store.search.length ? store.search : template.msg
+      })
     }
 
     onMounted(() => {


### PR DESCRIPTION
Quando se tem um tweet já digitado, ao trocar de template, o novo template não vem com o tweet digitado, porém a mensagem fica digitado no campo. Este PR tem como objetivo corrigir isso: ao ter um tweet já digitado, quando trocar de template, o novo template já vem com o que está digitado.